### PR TITLE
Add a simulator.isAvailable check for true

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
+++ b/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
@@ -60,8 +60,9 @@ function findMatchingSimulator(simulators, simulatorString) {
       const simulator = device[i];
       // Skipping non-available simulator
       if (
-        simulator.availability !== '(available)' &&
-        simulator.isAvailable !== 'YES'
+        simulator.availability !== '(available)' 
+        && simulator.isAvailable !== 'YES'
+        && simulator.isAvailable !== true
       ) {
         continue;
       }


### PR DESCRIPTION
Summary:
---------

Installing the Xcode 11 beta changes the result of isAvailable to `true` and `false` when searching for a simulator by name. 

E.g. 

```
{ 
    state: 'Shutdown',
    isAvailable: true,
    name: 'iPhone X',
    udid: 'xxx' 
},
{ 
    state: 'Shutdown',
    isAvailable: false,
    name: 'iPhone Xs',
    udid: 'xxx',
    availabilityError: 'runtime profile not found'
},
```

This fix adds a `&& simulator.isAvailable !== true` check to the existing simulator.isAvailable value checks.


Test Plan:
----------

1) run `react-native run-ios`
2) confirm working ✅
3) Install Xcode 11 beta
4) run `react-native run-ios`
5) confirm working ✅